### PR TITLE
[GFTCodeFixer]:  Update on docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "4000:4000"
     environment:
-      - DB_URL=postgresql://postgres:postgres@flask_db:5432/postgres
+      - DB_URL=${DB_URL}
     depends_on:
       - flask_db
   flask_db:
@@ -17,7 +17,7 @@ services:
     ports:
       - "5432:5432"
     environment:
-      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_USER=postgres
       - POSTGRES_DB=postgres
     volumes:


### PR DESCRIPTION
# ![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated for GFT AI Impact Bot for the dcd6e47ba53d40a953df8d76879eb9e53c6ce522

**Description:** The `docker-compose.yml` file has been updated to enhance security and flexibility by removing hardcoded database URLs and passwords. Instead of directly placing sensitive information in the file, environment variables are now used, which can be set outside of the file, such as in an environment-specific configuration file or through environment variable management in the deployment process.

**Summary:** 
- `docker-compose.yml` (modified)
  - The `DB_URL` for the `flask_app` service has been changed from a hardcoded connection string to an environment variable reference `${DB_URL}`.
  - The `POSTGRES_PASSWORD` for the `flask_db` service has been changed from a hardcoded value `postgres` to an environment variable reference `${POSTGRES_PASSWORD}`.

**Recommendation:** Reviewers should ensure that the environment variables `DB_URL` and `POSTGRES_PASSWORD` are properly set in the environment where `docker-compose` is run. This could be in a `.env` file or through another secure method of setting environment variables. It is also recommended to check that these changes are reflected in any documentation or deployment scripts that may be affected.

**Explanation of vulnerabilities:** 
- Before the changes, the database URL and password were hardcoded into the `docker-compose.yml` file, which is a security risk as it exposes sensitive information in source control. By using environment variables, the sensitive information is removed from the file, reducing the risk of accidental exposure.
- No direct code snippet is provided for the correction as the change is already implemented in the pull request. However, ensure that the environment variables are not included in any file that is committed to source control. Instead, use a secure method to set these variables at runtime. For example, if using a `.env` file, it should be added to `.gitignore` to prevent it from being committed.